### PR TITLE
Make setter methods chainable

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,17 +17,19 @@ var game = new Game();
 var board = game.board;
 
 // Initial position
-board.setPosition(Piece.PAWN_WHITE, [33, 38, 39, 43, 44]);
-board.setPosition(Piece.PAWN_BLACK, [12, 13, 14, 22, 24]);
-board.setPosition(Piece.DAME_WHITE, []);
-board.setPosition(Piece.DAME_BLACK, []);
+board
+  .setPosition(Piece.PAWN_WHITE, [33, 38, 39, 43, 44])
+  .setPosition(Piece.PAWN_BLACK, [12, 13, 14, 22, 24])
+  .setPosition(Piece.DAME_WHITE, [])
+  .setPosition(Piece.DAME_BLACK, []);
 
 // Different ways to define the list of movements
-game.addMove(33, 29);
-game.addMove(24, 42, [33]);
-game.addMove(43, 38);
-game.addMoveTxt("42x33");
-game.addMoveTxt("39x10");
+game
+  .addMove(33, 29)
+  .addMove(24, 42, [33])
+  .addMove(43, 38)
+  .addMoveTxt("42x33")
+  .addMoveTxt("39x10");
 ```
 
 **Read position, apply moves and get detailed information**
@@ -118,7 +120,7 @@ game.start();
 while (game.hasNext()){
     var m = game.getNextMove();
     console.log(m.getNotation());
-    
+
     game.next();
 }
 
@@ -135,7 +137,7 @@ while (game.hasNext()){
 
 ### Piece
 
-Draught board consists of squares on which the piece are located including : 
+Draught board consists of squares on which the piece are located including :
 - `Piece.EMPTY` : Empty square
 - `Piece.PAWN_WHITE`
 - `Piece.PAWN_BLACK`
@@ -144,7 +146,7 @@ Draught board consists of squares on which the piece are located including :
 
 ### Color
 
-The color of the piece on the square : 
+The color of the piece on the square :
 - `Color.NONE` : Empty square
 - `Color.WHITE`
 - `Color.BLACK`
@@ -158,10 +160,10 @@ Constructor : Create an empty draughts board. Default board size is 10 for Inter
 Add pieces on draught board to set the initial position. Default is 20  pawns on each side, depending of boardsize (cf. constructor).
 
 `.setPosition(piece, numbers)`
-Put Piece on squares. 
+Put Piece on squares.
 
 `.setPiece(piece, number)`
-Put Piece on specified square. 
+Put Piece on specified square.
 
 `.getPiece(number)`
 return the piece located on the square number.
@@ -199,8 +201,8 @@ moveNotation ::= {'move':textNotation, 'current':boolean}
 textNotation ::= \d[x|-]\d
 ```
 ```
-[{'number':1, 
-  'white':{'move':'35-30', 'current':false}, 
+[{'number':1,
+  'white':{'move':'35-30', 'current':false},
   'black':{'move':'25x34', 'current':false}
  }, ...]
 ```

--- a/src/brain/Diagonal.js
+++ b/src/brain/Diagonal.js
@@ -11,6 +11,7 @@ function Diagonal(isGD) {
 
 Diagonal.prototype.addCase = function(c) {
     this.squares.push(c);
+    return this;
 };
 
 Diagonal.prototype._size = function() {
@@ -299,7 +300,7 @@ Diagonal.prototype.getRaflesItem = function(squareNum, numSquaresPrevCaptured) {
 };
 
 Diagonal.prototype.toString = function() {
-    
+
     var type = "GD";
     if (!this.isGD){
         type = "TT";

--- a/src/brain/NTree.js
+++ b/src/brain/NTree.js
@@ -10,6 +10,7 @@ NTree.prototype.getItem = function() {
 
 NTree.prototype.setItem = function(item) {
     this.item = item;
+    return this;
 };
 
 NTree.prototype.hasLeft = function() {
@@ -45,6 +46,7 @@ NTree.prototype.setChildren = function(list) {
             }
         }
     }
+    return this;
 };
 
 // Retourne tous les fils

--- a/src/brain/PathFinder.js
+++ b/src/brain/PathFinder.js
@@ -58,7 +58,7 @@ PathFinder.prototype._treeToMovements = function(board, tree) {
 
             for (var j = 0; j < list.length; j++) {
                 var ri = list[j];
-                
+
                 // Starting square is not considered as a landing square
                 // unlike the final square (it can be the same).
                 if (ri.endingSquareNum != nStart || j != 0){
@@ -143,6 +143,7 @@ PathFinder.prototype.buildRafles = function(board, node, numSquaresPrevCaptured)
         // ---
         this.buildRafles(diag, nf, lcdp);
     }
+    return this;
 };
 
 PathFinder.prototype.displayTreePaths = function(tree) {
@@ -163,7 +164,7 @@ PathFinder.prototype.displayTreePaths = function(tree) {
 /** Retourne la diagonaleGD contenant une case donnée. */
 PathFinder.prototype._getDiagonalGD = function(board, number) {
     var diag = [];
-    loop: 
+    loop:
     for (var i = 0; i < board.conf['DIAGONALS_GD'].length; i++) {
         var diagonal = board.conf['DIAGONALS_GD'][i];
         for (var j = 0; j < diagonal.length; j++) {
@@ -186,7 +187,7 @@ PathFinder.prototype._getDiagonalGD = function(board, number) {
 /** Retourne la diagonaleTT contenant une case donnée. */
 PathFinder.prototype._getDiagonalTT = function(board, number) {
     var diag = [];
-    loop: 
+    loop:
     for (var i = 0; i < board.conf['DIAGONALS_TT'].length; i++) {
         var diagonal = board.conf['DIAGONALS_TT'][i];
         for (var j = 0; j < diagonal.length; j++) {

--- a/src/core/DraughtBoard.js
+++ b/src/core/DraughtBoard.js
@@ -20,7 +20,7 @@ function DraughtBoard(boardSize) {
     /** Active Squares */
     this.squares = []; // [Square]
 
-    
+
     /** Initialize active squares */
     for (var k = 1; k <= this.conf['SQ_MAX_NUM']; k++) {
         var c = new Square(k);
@@ -40,6 +40,7 @@ DraughtBoard.prototype.setInitialPosition = function() {
     for (var num = this.conf['W_POSITION'][0]; num <= this.conf['W_POSITION'][1]; num++) {
         this.setPiece(Piece.PAWN_WHITE, num);
     }
+    return this;
 };
 
 /** Pose des pièces sur le damier */
@@ -47,12 +48,14 @@ DraughtBoard.prototype.setPosition = function(piece, numbers) {
     for (var k = 0; k < numbers.length; k++) {
         this.setPiece(piece, numbers[k]);
     }
+    return this;
 };
 
 /** Ajouter une pièce sur une case. */
 DraughtBoard.prototype.setPiece = function(piece, number) {
     var c = this.getSquare(number);
     c.piece = piece;
+    return this;
 };
 
 /** Retourne une case. */
@@ -105,6 +108,7 @@ DraughtBoard.prototype.applyMove = function(move) {
             this.setPiece(Piece.DAME_BLACK, move.endingSquareNum);
         }
     }
+    return this;
 };
 
 /** Annule le mouvement sur le damier. */
@@ -133,6 +137,7 @@ DraughtBoard.prototype.applyMoveRev = function(move) {
             this.setPiece(Piece.PAWN_BLACK, move.startingSquareNum);
         }
     }
+    return this;
 };
 
 DraughtBoard.prototype.debugDraughtBoard = function() {

--- a/src/core/Game.js
+++ b/src/core/Game.js
@@ -17,7 +17,7 @@ Game.prototype.hasMove = function() {
 
 /**
  * Définition des mouvements
- * 
+ *
  * @param startNum
  *            Numéro de la case de départ (REQUIS)
  * @param endNum
@@ -46,6 +46,7 @@ Game.prototype.addMove = function(startNum, endNum, middleSquaresNum) {
     } else {
         console.log("addMove(" + startNum + ", " + endNum + ") : ERROR");
     }
+    return this;
 };
 
 
@@ -107,6 +108,7 @@ Game.prototype.addMoveTxt = function(move) {
     } else {
         console.log("addMove: ERREUR (1)");
     }
+    return this;
 };
 
 Game.prototype._getStatusNextIndex = function() {
@@ -187,15 +189,18 @@ Game.prototype.prev = function() {
 
 Game.prototype.start = function() {
     this._setIndex(-1);
+    return this;
 };
 
 Game.prototype.end = function() {
     this._setIndex(this._getLastIndex());
+    return this;
 };
 
 /** Position initiale = 0 ; Premier coup = 1. */
 Game.prototype.setCursor = function(position) {
     this._setIndex(position - 1);
+    return this;
 };
 
 /** Position initiale = -1 ; premier coup = 0 */
@@ -212,6 +217,7 @@ Game.prototype._setIndex = function(idx) {
             isOk = this.prev();
         }
     }
+    return this;
 };
 
 Game.prototype._getLastIndex = function() {
@@ -241,14 +247,14 @@ Game.prototype._hasError = function() {
 };
 
 
-// [{'number':1, 
-//   'white':{'move':'32x26', 'current':false}, 
+// [{'number':1,
+//   'white':{'move':'32x26', 'current':false},
 //   'black':{'move':'32x26', 'current':false}}]
 Game.prototype.getNotation = function(){
     var list = [];
-    
+
     if (this.moves.length > 0){
-    
+
         // is first move a black move ?
         var m = this.moves[0];
         var notation = m.getNotation();
@@ -258,14 +264,14 @@ Game.prototype.getNotation = function(){
             mapb['position'] = 1;
             mapb['move'] = notation;
             mapb['current'] = (0 == this.index);
-            
+
             var map = {};
             map['black'] = mapb;
-            map['number'] = 1;            
+            map['number'] = 1;
             list.push(map);
             shift = 1;
         }
-        
+
         var map = null;
         for (var k = 0 + shift; k < this.moves.length; k++) {
             var m = this.moves[k];
@@ -277,7 +283,7 @@ Game.prototype.getNotation = function(){
                 mapw['position'] = k + 1;
                 mapw['move'] = notation;
                 mapw['current'] = (k == this.index);
-                
+
                 map = {};
                 map['number'] = cpt;
                 map['white'] = mapw;
@@ -287,7 +293,7 @@ Game.prototype.getNotation = function(){
                 mapb['move'] = notation;
                 mapb['current'] = (k == this.index);
                 map['black'] = mapb;
-                
+
                 list.push(map);
                 map = null; // see after loop
             }

--- a/src/core/Move.js
+++ b/src/core/Move.js
@@ -21,9 +21,11 @@ function Move(startNum, endNum) {
 
 Move.prototype.addLandingSquareNum = function(squareNum) {
     this.landingSquaresNum.push(squareNum);
+    return this;
 };
 Move.prototype.addCapturedSquare = function(square) {
     this.capturedSquares.push(square);
+    return this;
 };
 
 Move.prototype.size = function() {


### PR DESCRIPTION
Just as it is dev-friendly and a best-practice, make methods that mutes game state chainable, e.g.:

``` javascript
board
  .setPosition(Piece.PAWN_WHITE, [33, 38, 39, 43, 44])
  .setPosition(Piece.PAWN_BLACK, [12, 13, 14, 22, 24])
  .setPosition(Piece.DAME_WHITE, [])
  .setPosition(Piece.DAME_BLACK, []);
```
